### PR TITLE
Add wordpress/docker-compose experiment

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,0 +1,18 @@
+# WordPress
+
+## Key observations 
+
+From experimenting with UI using Docker Compose
+
+- Really simple, streamlined process for creating posts and setting up layouts
+- REST API is available at `/wp-json`. Seems to be a full HATEOAS API, which
+  might be a useful property.
+- You can permalink posts and view them via the "slug" query param
+http://localhost/wp-json/wp/v2/posts?slug=test-content
+- Default permalink has date in it, but you can modify the format
+http://localhost/2022/09/25/test-content?rest_route=/wp/v2
+- Not seeing an obvious way to use WP to modify the set of strings.
+  - Maybe use a single WP post per screen per locale. Each WP post uses some
+    well-formatted string that the FE can parse.
+- Didn't test "media", but that should be a non-issue.
+- User auth seems well-supported - each author can only modify their own posts

--- a/wordpress/docker-compose/README.md
+++ b/wordpress/docker-compose/README.md
@@ -1,0 +1,23 @@
+# WordPress + Docker Compose 
+
+Simple experiment to try the WordPress UI
+
+Following https://docs.docker.com/samples/wordpress/
+
+REST API reference: https://developer.wordpress.org/rest-api/
+
+## Steps:
+
+1. Install docker-compose, typically via Docker desktop on Mac/Windows https://www.docker.com/products/docker-desktop/
+
+2. Start via the script below and verify that it  runs on `http://localhost:80`
+
+## Scripts
+
+- Start: `docker compose up -d``
+
+- Stop (db will persist): `docker compose down`
+
+- Uninstall (db will be deleted): `docker compose down --volumes`
+
+

--- a/wordpress/docker-compose/docker-compose.yml
+++ b/wordpress/docker-compose/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  db:
+    # We use a mariadb image which supports both amd64 & arm64 architecture
+    image: mariadb:10.6.4-focal
+    # If you really want to use MySQL, uncomment the following line
+    #image: mysql:8.0.27
+    command: '--default-authentication-plugin=mysql_native_password'
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+    expose:
+      - 3306
+      - 33060
+  wordpress:
+    image: wordpress:latest
+    volumes:
+      - wp_data:/var/www/html
+    ports:
+      - 80:80
+    restart: always
+    environment:
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=wordpress
+      - WORDPRESS_DB_PASSWORD=wordpress
+      - WORDPRESS_DB_NAME=wordpress
+volumes:
+  db_data:
+  wp_data:


### PR DESCRIPTION
Add instructions on how to setup WordPress using docker-compose.

Findings are in `wordpress/README.md` and `wordpress/docker-compose/README.md`.

Google doc has been updated